### PR TITLE
Refactor theme colours

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -6,7 +6,7 @@ setOptions({
 });
 
 configure(() => {
-  require('../src/stories/intro.story.js');
+  require('../src/stories/theme.story.js');
   require('../src/stories/Text.story.js');
   require('../src/stories/Wrapper.story.js');
   require('../src/stories/List.story.js');

--- a/src/components/Header/MenuIcon.js
+++ b/src/components/Header/MenuIcon.js
@@ -4,11 +4,15 @@ import styled, { css } from 'styled-components';
 import { MdMenu } from 'react-icons/md';
 import { Theme } from '../../types/Theme';
 
-const HeaderMenuIcon = styled(({ isActive, ...rest }) => <MdMenu {...rest} />)`
+const HeaderMenuIcon = styled(({ isActive: boolean, ...rest }) => (
+  <MdMenu {...rest} />
+))`
   ${({ theme, isActive }: { theme: Theme, isActive: boolean }) => css`
     margin-right: ${theme.spacing.larger};
     font-size: ${theme.fontSizes.h3};
-    color: ${isActive ? theme.colours.primary : theme.colours.text};
+    color: ${isActive
+      ? theme.colours.primary.light
+      : theme.colours.neutral.darkest};
 
     &:hover {
       cursor: pointer;

--- a/src/components/Header/NavLink.js
+++ b/src/components/Header/NavLink.js
@@ -4,7 +4,7 @@ import Link from '../Link/Link';
 export default function NavLink(activeClassName) {
   return styled(Link)`
     ${({ theme }) => css`
-      color: ${theme.colours.text};
+      color: ${theme.colours.neutral.darkest};
       font-size: ${theme.fontSizes.ui};
       font-weight: ${theme.fontWeight.regular};
       text-decoration: none;
@@ -12,7 +12,7 @@ export default function NavLink(activeClassName) {
       margin-right: ${theme.spacing.medium};
 
       &.${activeClassName} {
-        color: ${theme.colours.primary};
+        color: ${theme.colours.primary.light};
       }
     `};
   `;

--- a/src/components/Logo/Logo.js
+++ b/src/components/Logo/Logo.js
@@ -1,5 +1,4 @@
 // @flow
-
 import * as React from 'react';
 import Text from '../Text/Text';
 

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -7,6 +7,7 @@ import type {
   ThemeFontSettings,
   ThemeFonts,
   ThemeColours,
+  ColourScaleValues,
 } from '../../types/Theme';
 import type { StyleFunction } from '../../types/StyleFunction';
 
@@ -20,7 +21,10 @@ type TextStyleProps = {
   size?: ThemeFontSettings,
   weight?: 400 | 500 | 700 | 900 | 'bold' | 'normal' | 'light',
   lineHeight?: ThemeFontSettings,
-  colour?: ThemeColours,
+  colour?: {
+    type: ThemeColours,
+    shade: ColourScaleValues,
+  },
   italic?: boolean,
   font?: ThemeFonts,
   theme?: Theme,
@@ -50,11 +54,12 @@ const setFontFamily: StyleFunction = ({ font, theme }: TextStyleProps) =>
     font-family: ${theme.fonts[font]};
   `;
 
-const setTextColour: StyleFunction = ({ theme, colour }) =>
+const setTextColour: StyleFunction = ({ theme, colour: { type, shade } }) =>
   theme &&
-  colour &&
+  type &&
+  shade &&
   css`
-    color: ${theme.colours[colour]};
+    color: ${theme.colours[type][shade]};
   `;
 
 const setLineHeight: StyleFunction = ({
@@ -95,7 +100,10 @@ Text.defaultProps = {
   lineHeight: 'ui',
   italic: false,
   font: 'body',
-  colour: 'text',
+  colour: {
+    type: 'neutral',
+    shade: 'darkest',
+  },
 };
 
 export default Text;

--- a/src/components/Text/Text.test.js
+++ b/src/components/Text/Text.test.js
@@ -50,7 +50,7 @@ describe('Text [component]', () => {
         const component = mount(
           <ThemeProvider theme={theme()}>
             <Text
-              colour="primary"
+              colour={{ type: 'primary', shade: 'dark' }}
               lineHeight="h3"
               size="ui"
               italic="true"
@@ -60,7 +60,10 @@ describe('Text [component]', () => {
             </Text>
           </ThemeProvider>,
         );
-        expect(component).toHaveStyleRule('color', theme().colours.primary);
+        expect(component).toHaveStyleRule(
+          'color',
+          theme().colours.primary.dark,
+        );
         expect(component).toHaveStyleRule('line-height', theme().lineHeight.h3);
         expect(component).toHaveStyleRule('font-size', theme().fontSizes.ui);
         expect(component).toHaveStyleRule('font-style', 'italic');

--- a/src/components/Wrapper/Wrapper.js
+++ b/src/components/Wrapper/Wrapper.js
@@ -4,21 +4,13 @@ import * as React from 'react';
 import Styled, { css } from 'styled-components';
 
 import type { StyleFunction } from '../../types/StyleFunction';
-import type { Theme, ThemeColours } from '../../types/Theme';
+import type { Theme } from '../../types/Theme';
 
 type WrapperProps = {
   children: React.Node,
-  colour?: ThemeColours,
   constrain?: boolean,
   theme: Theme,
 };
-
-const setBackground: StyleFunction = ({ theme, colour }: WrapperProps) =>
-  theme &&
-  colour &&
-  css`
-    background-color: ${theme.colours[colour]};
-  `;
 
 const constrainChildren: StyleFunction = ({ constrain }: WrapperProps) =>
   constrain
@@ -35,7 +27,6 @@ const wrapperPadding: StyleFunction = ({ theme }) =>
   `;
 
 const Wrapper = Styled.div`  
-  ${props => setBackground(props)}
   ${props => constrainChildren(props)}
   ${props => wrapperPadding(props)}
 
@@ -43,7 +34,6 @@ const Wrapper = Styled.div`
 `;
 
 Wrapper.defaultProps = {
-  colour: 'none',
   constrain: true,
 };
 

--- a/src/components/Wrapper/Wrapper.test.js
+++ b/src/components/Wrapper/Wrapper.test.js
@@ -72,13 +72,6 @@ describe('Layout [Container]', () => {
       test('with constrain set to false', () => {
         expect(wrapper).toHaveStyleRule('max-width', '100%');
       });
-
-      test('with colour set to primary', () => {
-        expect(wrapper).toHaveStyleRule(
-          'background-color',
-          theme().colours.primary,
-        );
-      });
     });
   });
 });

--- a/src/stories/components/Theme.js
+++ b/src/stories/components/Theme.js
@@ -1,0 +1,47 @@
+// @flow
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+import { type ColourScale, type ThemeColours } from '../../types/Theme';
+import Text from '../../components/Text/Text';
+
+const PalleteList = styled.div`
+  display: flex;
+`;
+
+const PalleteContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Pallete = styled.div`
+  ${({ theme: t, colour }) => css`
+    background-color: ${colour};
+    width: ${t.spacing.xxLarge};
+    height: ${t.spacing.xxLarge};
+  `};
+`;
+
+const ColourPalette = ({
+  colourGroupName,
+  colourList,
+}: {
+  colourGroupName: ThemeColours,
+  colourList: ColourScale,
+}) => (
+  <React.Fragment>
+    <Text weight="bold" font="body" size="ui" lineHeight="ui">
+      {colourGroupName}
+    </Text>
+    <PalleteList>
+      {Object.entries(colourList).map(([key, val]) => (
+        <PalleteContainer>
+          <Pallete colour={val} />
+          <Text size="tiny">{key}</Text>
+        </PalleteContainer>
+      ))}
+    </PalleteList>
+  </React.Fragment>
+);
+
+export default ColourPalette;

--- a/src/stories/intro.story.js
+++ b/src/stories/intro.story.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import { storiesOf } from '@storybook/react';
-
-storiesOf('Welcome', module).add('Intro', () => (
-  <div>
-    <h1>Welcome to the storybook</h1>
-    <p>docs etc</p>
-  </div>
-));

--- a/src/stories/theme.story.js
+++ b/src/stories/theme.story.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { ThemeProvider } from 'styled-components';
+import theme from '../styles/theme';
+import Wrapper from '../components/Wrapper/Wrapper';
+
+import ColourPalette from './components/Theme';
+
+storiesOf('Theme', module).add('Colours', () => (
+  <ThemeProvider theme={theme()}>
+    <Wrapper constrain>
+      {Object.entries(theme().colours).map(([groupName, values]) => (
+        <ColourPalette colourGroupName={groupName} colourList={values} />
+      ))}
+    </Wrapper>
+  </ThemeProvider>
+));

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -3,13 +3,38 @@ import type { Theme } from '../types/Theme';
 
 export default (): Theme => ({
   colours: {
-    background: '#FFFFFF',
-    primary: '#b7dbe8',
-    secondary: '#deeef4',
-    tertiary: '#f1f8fb',
-    success: '#C8EED1',
-    error: '#EEC8C8',
-    text: '#444444',
+    primary: {
+      lightest: '#f1f8fb',
+      lighter: '#deeef4',
+      light: '#b7dbe8',
+      dark: '#43a1c3',
+      darker: '#3383a0',
+      darkest: '#1a4453',
+    },
+    neutral: {
+      lightest: '#e1e7ec',
+      lighter: '#aebece',
+      light: '#919fb2',
+      dark: '#6e7a8b',
+      darker: '#404b5b',
+      darkest: '#202833',
+    },
+    error: {
+      lightest: '#faefef',
+      lighter: '#f4dbdb',
+      light: '#EEC8C8',
+      dark: '#dc8e8e',
+      darker: '#d06767',
+      darkest: '#c44040',
+    },
+    success: {
+      lightest: '#effaf2',
+      lighter: '#dbf4e1',
+      light: '#C8EED1',
+      dark: '#a1e2b0',
+      darker: '#7ad690',
+      darkest: '#40c45f',
+    },
   },
   spacing: {
     xxSmall: '2px',

--- a/src/types/Theme.js
+++ b/src/types/Theme.js
@@ -1,16 +1,20 @@
 // @flow
+export type ThemeColours = 'primary' | 'neutral' | 'success' | 'error';
 
-export type ThemeColours =
-  | 'background'
-  | 'primary'
-  | 'secondary'
-  | 'tertiary'
-  | 'success'
-  | 'error'
-  | 'text';
+export type ColourScaleValues =
+  | 'lightest'
+  | 'lighter'
+  | 'light'
+  | 'dark'
+  | 'darker'
+  | 'darkest';
+
+export type ColourScale = {
+  [ColourScaleValues]: string,
+};
 
 export type Colours = {
-  [ThemeColours]: string,
+  [ThemeColours]: ColourScale,
 };
 
 export type ThemeSpacing =


### PR DESCRIPTION
Using this as a guide:

https://refactoringui.com/previews/building-your-color-palette/

- refactors theme colours into objects containing shades
- more robust api around getting colours from the theme
- wrote a story for the colours aspect of the theme.